### PR TITLE
update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-dismiss",
-  "version": "1.7.121",
+  "version": "1.7.122",
   "homepage": "https://aquaductape.github.io/solid-dismiss/",
   "description": "Handles \"click outside\" behavior for popup menu. Closing is triggered by click/focus outside of popup element or pressing \"Escape\" key.",
   "license": "MIT",
@@ -32,6 +32,7 @@
   "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "solid": "./dist/source/index.jsx",
       "default": "./dist/esm/index.js"
     }


### PR DESCRIPTION
Update package.json for a correct behaviour when resolving types with `node16` moduleResolution.
Currently,  when import the pacakge, tsc will throw error `There are types at 'node_modules/solid-dismiss/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports".`
Reference: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html